### PR TITLE
Show a movie's original title when it differs by language

### DIFF
--- a/src/app/movies/[id]/[slug]/page-content.tsx
+++ b/src/app/movies/[id]/[slug]/page-content.tsx
@@ -271,6 +271,12 @@ export default function PageContent({
             {movie.title}
           </OutlineHeading>
 
+          {movie.originalTitle && (
+            <p className={styles.originalTitle}>
+              Original title: {movie.originalTitle}
+            </p>
+          )}
+
           <div className={styles.metadata}>
             {!!movie.year && <span>{movie.year}</span>}
             {!!movie.classification && (

--- a/src/app/movies/[id]/[slug]/page.module.css
+++ b/src/app/movies/[id]/[slug]/page.module.css
@@ -57,6 +57,12 @@
   margin-bottom: 16px;
 }
 
+.originalTitle {
+  font-style: italic;
+  color: var(--color-muted-gray);
+  margin-bottom: 16px;
+}
+
 .metadata {
   display: flex;
   align-items: center;

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,6 +287,8 @@ export type Movie = {
   id: string;
   title: string;
   normalizedTitle: string;
+  /** The title in its original language, when that isn't English and differs from `title`. */
+  originalTitle?: string;
   isUnmatched?: boolean;
   classification?: Classification;
   overview?: string;


### PR DESCRIPTION
## Summary

- Adds an optional `originalTitle` field to the `Movie` type (`src/types.ts`).
- Renders it under the title on the movie page (`src/app/movies/[id]/[slug]/page-content.tsx`) as "Original title: …", only when present — e.g. Amélie's original *Le Fabuleux Destin d'Amélie Poulain*.
- Pairs with the upstream data change in [clusterflick/scripts#572](https://github.com/clusterflick/scripts/pull/572), which populates the field from TMDB's `original_title`/`original_language`, set only when the original language isn't English and differs from the display title. Existing data files won't carry this field until that pipeline change ships, so the line simply won't render until then.

## Test plan

- [x] `npm run lint` (typecheck + eslint)
- [x] `npx prettier --check` on changed files
- [ ] Manual check in Storybook / dev server once a movie with `originalTitle` is available in the dataset


---
_Generated by [Claude Code](https://claude.ai/code/session_0179i2JSsCvNfR1TLc7MVwGR)_