### PR TITLE
Show original language and match on original title in search

### DIFF
--- a/src/app/movies/[id]/[slug]/page-content.tsx
+++ b/src/app/movies/[id]/[slug]/page-content.tsx
@@ -28,6 +28,7 @@ import { filterManager, describeFilters } from "@/lib/filters";
 import { getCinemaVenueIds } from "@/utils/get-cinema-venue-ids";
 import { SHOW_ALL_HASH } from "@/utils/get-movie-url";
 import { formatDuration, formatDateLong } from "@/utils/format-date";
+import { formatLanguage } from "@/utils/format-language";
 import PageHeader from "@/components/page-header";
 import HeroSection from "@/components/hero-section";
 import OutlineHeading from "@/components/outline-heading";
@@ -285,6 +286,11 @@ export default function PageContent({
               </span>
             )}
             {!!movie.duration && <span>{formatDuration(movie.duration)}</span>}
+            {!!movie.originalLanguage && (
+              <span className={styles.language}>
+                {formatLanguage(movie.originalLanguage)}
+              </span>
+            )}
           </div>
 
           <GenresList

--- a/src/app/movies/[id]/[slug]/page.module.css
+++ b/src/app/movies/[id]/[slug]/page.module.css
@@ -74,7 +74,8 @@
   color: var(--color-electric-blue);
 }
 
-.classification {
+.classification,
+.language {
   padding: 4px 12px;
   background-color: rgba(var(--color-electric-blue-rgb), 0.2);
   border: 1px solid var(--color-electric-blue);

--- a/src/lib/filters/modules/search.ts
+++ b/src/lib/filters/modules/search.ts
@@ -45,10 +45,14 @@ export const searchFilter: FilterModule<FilterId.Search> = {
     const result: MoviesRecord = {};
 
     for (const [id, movie] of Object.entries(movies)) {
-      // Match against alternative spellings of both titles
+      // Match against alternative spellings of both titles, plus the
+      // original-language title for foreign-language films (e.g. searching
+      // "Fabuleux" finds Amélie).
       const titleMatch =
         matchesSearchQuery(movie.normalizedTitle || "", query) ||
-        matchesSearchQuery(movie.title, query);
+        matchesSearchQuery(movie.title, query) ||
+        (!!movie.originalTitle &&
+          matchesSearchQuery(movie.originalTitle, query));
 
       if (titleMatch) {
         result[id] = movie;

--- a/src/types.ts
+++ b/src/types.ts
@@ -289,6 +289,8 @@ export type Movie = {
   normalizedTitle: string;
   /** The title in its original language, when that isn't English and differs from `title`. */
   originalTitle?: string;
+  /** ISO 639-1 code of the film's original language, when that isn't English. */
+  originalLanguage?: string;
   isUnmatched?: boolean;
   classification?: Classification;
   overview?: string;

--- a/src/utils/format-language.ts
+++ b/src/utils/format-language.ts
@@ -1,0 +1,6 @@
+const languageNames = new Intl.DisplayNames(["en"], { type: "language" });
+
+/** ISO 639-1 code ("fr") → English display name ("French"). Falls back to the code itself for anything Intl doesn't recognise. */
+export function formatLanguage(code: string): string {
+  return languageNames.of(code) ?? code;
+}


### PR DESCRIPTION
## Summary

Follow-up to #73 (merged). Two related additions:

- Adds `originalLanguage` to the `Movie` type and shows it as a pill in the movie page's metadata row, next to year/classification/duration — e.g. "French" for Amélie. Uses `Intl.DisplayNames` (`src/utils/format-language.ts`) to turn the ISO 639-1 code into a readable name, no lookup table needed. Populated by [clusterflick/scripts#573](https://github.com/clusterflick/scripts/pull/573).
- The main search box (`src/lib/filters/modules/search.ts`) now also matches a film's `originalTitle`, so searching "Fabuleux" finds Amélie via its French original title — same pattern as the existing `title`/`normalizedTitle` matching.

## Test plan

- [x] `npm run lint` (typecheck + eslint)
- [x] `npx prettier --check` on changed files
- [x] Verified `Intl.DisplayNames` output for a few ISO codes (fr → French, ja → Japanese, es → Spanish)
- [ ] Manual check in Storybook / dev server once a movie with `originalLanguage`/`originalTitle` is available in the dataset


---
_Generated by [Claude Code](https://claude.ai/code/session_0179i2JSsCvNfR1TLc7MVwGR)_